### PR TITLE
Fix Railway healthcheck host blocking

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
   },
   preview: {
     host: '0.0.0.0',
-    port: parseInt(process.env.PORT || '4173')
+    port: parseInt(process.env.PORT || '4173'),
+    allowedHosts: ['healthcheck.railway.app']
   },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- Adds `healthcheck.railway.app` to `preview.allowedHosts` in Vite config
- Resolves 403 blocked request error during Railway deployment
- Allows Railway's healthcheck system to properly access the application

## Test plan
- [ ] Deploy to Railway and verify healthcheck passes
- [ ] Confirm application starts successfully
- [ ] Verify no 403 errors in deployment logs