### PR TITLE
Fix Railway domain blocking - add missing allowed hosts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,11 @@ export default defineConfig({
   preview: {
     host: '0.0.0.0',
     port: parseInt(process.env.PORT || '4173'),
-    allowedHosts: ['healthcheck.railway.app']
+    allowedHosts: [
+      'healthcheck.railway.app',
+      'puka-staging.up.railway.app',
+      '.up.railway.app' // Allow all Railway subdomains
+    ]
   },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- Adds `puka-staging.up.railway.app` to allowed hosts for staging environment access
- Adds `.up.railway.app` wildcard to allow all Railway subdomains  
- Builds on PR #35 which only added healthcheck domain
- Fixes remaining 403 blocked request errors during deployment

## Test plan
- [ ] Deploy to Railway staging and verify no 403 errors
- [ ] Confirm both healthcheck and app access work properly
- [ ] Verify deployment completes successfully