### PR TITLE
Fix production auth endpoints for Railway deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:e2e:report": "playwright show-report",
     "type-check": "tsc --noEmit",
     "railway:build": "npm run build",
-    "railway:start": "npm run preview",
+    "railway:start": "node server.js",
     "db:setup": "./scripts/setup-db.sh",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
+    "express": "^4.19.2",
     "@types/react-window": "^1.8.8",
     "better-auth": "^1.2.12",
     "papaparse": "^5.5.3",

--- a/railway.json
+++ b/railway.json
@@ -16,7 +16,10 @@
       "variables": {
         "NODE_ENV": "production",
         "VITE_APP_ENV": "production",
-        "VITE_APP_VERSION": "2.0.0"
+        "VITE_APP_VERSION": "2.0.0",
+        "VITE_AUTH_URL": "${{RAILWAY_PUBLIC_DOMAIN}}",
+        "BETTER_AUTH_URL": "${{RAILWAY_PUBLIC_DOMAIN}}",
+        "APP_URL": "${{RAILWAY_PUBLIC_DOMAIN}}"
       }
     }
   }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,76 @@
+import express from 'express';
+import { createServer as createViteServer } from 'vite';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import { auth } from './src/lib/auth-server.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PORT = process.env.PORT || 5173;
+const isProduction = process.env.NODE_ENV === 'production';
+
+async function createServer() {
+  const app = express();
+
+  if (isProduction) {
+    // In production, serve built files
+    app.use(express.static(path.join(__dirname, 'dist')));
+    
+    // Handle auth routes in production
+    app.use('/api/auth/*', async (req, res) => {
+      try {
+        const authRequest = new Request(`${req.protocol}://${req.get('host')}${req.originalUrl}`, {
+          method: req.method,
+          headers: req.headers,
+          body: req.method !== 'GET' && req.method !== 'HEAD' ? JSON.stringify(req.body) : undefined,
+        });
+        
+        const authResponse = await auth.handler(authRequest);
+        
+        // Set response headers
+        authResponse.headers.forEach((value, key) => {
+          res.setHeader(key, value);
+        });
+        
+        res.status(authResponse.status);
+        
+        if (authResponse.body) {
+          const reader = authResponse.body.getReader();
+          const pump = () => reader.read().then(({ done, value }) => {
+            if (done) {
+              res.end();
+              return;
+            }
+            res.write(Buffer.from(value));
+            return pump();
+          });
+          pump();
+        } else {
+          res.end();
+        }
+      } catch (error) {
+        console.error('Auth route error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    });
+
+    // Serve SPA - all other routes return index.html
+    app.get('*', (req, res) => {
+      res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+    });
+  } else {
+    // Development mode - use Vite dev server
+    const vite = await createViteServer({
+      server: { middlewareMode: true },
+      appType: 'spa'
+    });
+    
+    app.use(vite.ssrFixStacktrace);
+    app.use(vite.middlewares);
+  }
+
+  app.listen(PORT, '0.0.0.0', () => {
+    console.log(`Server running on port ${PORT} in ${isProduction ? 'production' : 'development'} mode`);
+  });
+}
+
+createServer().catch(console.error);

--- a/src/lib/auth-server.ts
+++ b/src/lib/auth-server.ts
@@ -19,6 +19,8 @@ export const auth = betterAuth({
   trustedOrigins: [
     "http://localhost:5173",
     "http://localhost:3000",
+    "https://puka-production.up.railway.app",
+    ...(process.env.BETTER_AUTH_TRUSTED_ORIGINS?.split(",") || []),
   ],
 });
 


### PR DESCRIPTION
## Summary
- Fixes 404 errors on `/api/auth/*` endpoints in production
- Configures proper production domain in auth trusted origins
- Creates Express server to handle auth routes in production
- Updates Railway environment variables for auth URLs

## Problem
The authentication endpoints were returning 404 in production because:
- Auth routes were handled by Vite dev middleware, not available in production
- Production used `vite preview` which only serves static files
- `trustedOrigins` didn't include the production domain
- Auth URLs defaulted to localhost in production

## Solution
1. **Added production domain to trusted origins** in `auth-server.ts`
2. **Created Express production server** (`server.js`) to handle auth routes
3. **Updated Railway config** with proper environment variables using `${{RAILWAY_PUBLIC_DOMAIN}}`
4. **Switched from `vite preview` to `node server.js`** for production

## Test Plan
- [ ] Deploy to Railway and verify auth endpoints return 200 instead of 404
- [ ] Test user registration at `/api/auth/sign-up/email`
- [ ] Test user login at `/api/auth/sign-in/email`
- [ ] Verify session management works in production