### PR TITLE
Enable global search and reading-day toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ function AppContent() {
     deleteBook,
     getExportData,
     markReadingDay,
+    removeReadingDayEntry,
     refresh,
   } = useStorage()
 
@@ -299,6 +300,41 @@ function AppContent() {
     }
   }
 
+  const handleMarkReadingDay = async (): Promise<boolean> => {
+    try {
+      const marked = await markReadingDay()
+      if (marked) {
+        success('Logged your reading day!', {
+          title: 'Reading Recorded',
+          duration: 4000,
+        })
+        await refresh()
+      } else {
+        showError('Failed to mark reading day. Please try again.')
+      }
+      return marked
+    } catch (err) {
+      showError('Failed to mark reading day. Please try again.')
+      return false
+    }
+  }
+
+  const handleUnmarkReadingDay = async (): Promise<boolean> => {
+    try {
+      const today = new Date().toISOString().split('T')[0]
+      await removeReadingDayEntry(today)
+      success("Today's reading entry removed", {
+        title: 'Entry Removed',
+        duration: 4000,
+      })
+      await refresh()
+      return true
+    } catch (err) {
+      showError('Failed to remove today\'s reading entry. Please try again.')
+      return false
+    }
+  }
+
   // Show error state if there's an error
   if (error) {
     return (
@@ -333,7 +369,8 @@ function AppContent() {
         onUpdateBook={handleUpdateBook}
         onDeleteBook={handleDeleteBook}
         onImportComplete={handleImportComplete}
-        onMarkReadingDay={markReadingDay}
+        onMarkReadingDay={handleMarkReadingDay}
+        onUnmarkReadingDay={handleUnmarkReadingDay}
         onStreakUpdate={refresh}
         loading={loading}
       />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -30,6 +30,7 @@ interface DashboardProps {
   onDeleteBook?: (bookId: number) => Promise<void>
   onImportComplete?: (result: ImportResult) => void
   onMarkReadingDay?: () => Promise<boolean>
+  onUnmarkReadingDay?: () => Promise<boolean>
   onStreakUpdate?: () => void
   loading?: boolean
   className?: string
@@ -48,6 +49,7 @@ const Dashboard: React.FC<DashboardProps> = ({
   onDeleteBook,
   onImportComplete,
   onMarkReadingDay,
+  onUnmarkReadingDay,
   onStreakUpdate,
   loading = false,
   className = '',
@@ -277,22 +279,20 @@ const Dashboard: React.FC<DashboardProps> = ({
 
   // Filter books based on active filter and search query
   const filteredBooks = useMemo(() => {
+    const query = debouncedSearchQuery.toLowerCase().trim()
     let filtered = books
 
-    // Apply status filter
-    if (activeFilter !== 'all') {
-      filtered = filtered.filter((book) => book.status === activeFilter)
-    }
-
-    // Apply search filter
-    if (debouncedSearchQuery.trim()) {
-      const query = debouncedSearchQuery.toLowerCase().trim()
+    if (query) {
+      // Global search across all statuses when query is present
       filtered = filtered.filter(
         (book) =>
           book.title.toLowerCase().includes(query) ||
           book.author.toLowerCase().includes(query) ||
           (book.notes && book.notes.toLowerCase().includes(query))
       )
+    } else if (activeFilter !== 'all') {
+      // Apply status filter only when no search query
+      filtered = filtered.filter((book) => book.status === activeFilter)
     }
 
     return filtered
@@ -921,6 +921,7 @@ const Dashboard: React.FC<DashboardProps> = ({
             books={books}
             streakHistory={streakHistory}
             onMarkReadingDay={onMarkReadingDay}
+            onUnmarkReadingDay={onUnmarkReadingDay}
             onStreakUpdate={onStreakUpdate}
             showDetails={true}
             compact={false}

--- a/src/components/StreakDisplay.tsx
+++ b/src/components/StreakDisplay.tsx
@@ -10,6 +10,8 @@ interface StreakDisplayProps {
   streakHistory?: StreakHistory;
   /** Function to manually mark today as a reading day */
   onMarkReadingDay?: () => Promise<boolean>;
+  /** Function to remove today's reading day */
+  onUnmarkReadingDay?: () => Promise<boolean>;
   /** Whether today has reading activity */
   hasReadToday?: boolean;
   /** Compact display mode */
@@ -26,6 +28,7 @@ const StreakDisplay: React.FC<StreakDisplayProps> = ({
   books,
   streakHistory,
   onMarkReadingDay,
+  onUnmarkReadingDay,
   hasReadToday = false,
   compact = false,
   className = '',
@@ -41,27 +44,38 @@ const StreakDisplay: React.FC<StreakDisplayProps> = ({
     return calculateStreakWithHistory(books, streakHistory, 30); // 30 pages as default daily goal
   }, [books, streakHistory]);
 
-  const handleMarkReadingDay = async () => {
-    if (!onMarkReadingDay || isMarkingReadingDay) return;
-    
+  
+  const { currentStreak, longestStreak, todayProgress, dailyGoal, hasReadToday: calculatedHasReadToday } = streakData;
+
+  // Use calculated value or fallback to prop
+  const actualHasReadToday = calculatedHasReadToday || hasReadToday;
+
+  const handleToggleReadingDay = async () => {
+    if (isMarkingReadingDay) return;
+
     try {
       setIsMarkingReadingDay(true);
-      const success = await onMarkReadingDay();
-      if (!success) {
-        console.error('Failed to mark reading day');
+      if (actualHasReadToday) {
+        if (onUnmarkReadingDay) {
+          const success = await onUnmarkReadingDay();
+          if (!success) {
+            console.error('Failed to unmark reading day');
+          }
+        }
+      } else {
+        if (onMarkReadingDay) {
+          const success = await onMarkReadingDay();
+          if (!success) {
+            console.error('Failed to mark reading day');
+          }
+        }
       }
     } catch (error) {
-      console.error('Error marking reading day:', error);
+      console.error('Error toggling reading day:', error);
     } finally {
       setIsMarkingReadingDay(false);
     }
   };
-  
-  const { currentStreak, longestStreak, todayProgress, dailyGoal, hasReadToday: calculatedHasReadToday } = streakData;
-  
-  // Use calculated value or fallback to prop
-  const actualHasReadToday = calculatedHasReadToday || hasReadToday;
-
 
   const getStreakMessage = () => {
     if (currentStreak === 0) {
@@ -174,25 +188,24 @@ const StreakDisplay: React.FC<StreakDisplayProps> = ({
               {getStreakMessage()}
             </span>
             <div className="flex items-center gap-2">
-              {/* I Read Today Button - Always show when onMarkReadingDay is available */}
-              {onMarkReadingDay && (
+              {/* I Read Today Button - Allows toggle when both handlers provided */}
+              {(onMarkReadingDay || onUnmarkReadingDay) && (
                 <button
-                  onClick={handleMarkReadingDay}
-                  disabled={isMarkingReadingDay || actualHasReadToday}
-                  className={`text-xs px-3 py-1 rounded-full transition-all duration-200 
+                  onClick={handleToggleReadingDay}
+                  disabled={isMarkingReadingDay}
+                  className={`text-xs px-3 py-1 rounded-full transition-all duration-200
                            focus:outline-none focus:ring-2 focus:ring-white/50
-                           ${actualHasReadToday 
-                             ? 'bg-green-500/30 text-white cursor-default' 
+                           ${actualHasReadToday
+                             ? 'bg-green-500/30 text-white hover:bg-green-500/40'
                              : 'bg-white/20 hover:bg-white/30 disabled:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed'
                            }`}
-                  aria-label={actualHasReadToday ? "Already marked as read today" : "Mark today as a reading day"}
+                  aria-label={actualHasReadToday ? 'Undo reading day' : 'Mark today as a reading day'}
                 >
-                  {isMarkingReadingDay 
-                    ? '...' 
-                    : actualHasReadToday 
-                      ? '✅ Read today' 
-                      : '📚 I read today'
-                  }
+                  {isMarkingReadingDay
+                    ? '...'
+                    : actualHasReadToday
+                      ? '✅ Read today'
+                      : '📚 I read today'}
                 </button>
               )}
               


### PR DESCRIPTION
## Summary
- allow searching across all book statuses, ignoring active filters when a query is entered
- add ability to undo "Read Today" with immediate feedback and toast notifications

## Testing
- `npm run lint src/App.tsx src/components/Dashboard.tsx src/components/StreakDisplay.tsx`
- `npm test -- --run` *(fails: shows timeouts in importService.streak.test.ts and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_689861a97290832ca44e5dbb8b968adf